### PR TITLE
Feature: Add support for streaming data to mixins.apply_descrambler

### DIFF
--- a/pytube/mixins.py
+++ b/pytube/mixins.py
@@ -91,15 +91,26 @@ def apply_descrambler(stream_data, key):
     {'foo': [{'bar': '1', 'var': 'test'}, {'em': '5', 't': 'url encoded'}]}
 
     """
+    import urllib.parse
     if key == 'url_encoded_fmt_stream_map' and not stream_data.get('url_encoded_fmt_stream_map'):
-        formats = json.loads(stream_data['player_response'])[
-            'streamingData']['formats']
-        formats.extend(json.loads(stream_data['player_response'])[
-                       'streamingData']['adaptiveFormats'])
-        stream_data[key] = [{u'url': format_item[u'url'],
-                             u'type': format_item[u'mimeType'],
-                             u'quality': format_item[u'quality'],
-                             u'itag': format_item[u'itag']} for format_item in formats]
+
+        try:
+            formats = json.loads(stream_data['player_response'])['streamingData']['formats']
+            formats.extend(json.loads(stream_data['player_response'])['streamingData']['adaptiveFormats'])
+        except:
+            formats = json.loads(stream_data['player_response'])['streamingData']['adaptiveFormats']
+        try:
+            stream_data[key] = [{u'url': format_item[u'url'],
+                                 u'type': format_item[u'mimeType'],
+                                 u'quality': format_item[u'quality'],
+                                 u'itag': format_item[u'itag']} for format_item in formats]
+        except:
+            stream_data[key] = [{u'url': urllib.parse.unquote([url_item for url_item in format_item[u'cipher'].split("&") if "url=" in url_item][0].split("=")[1]),
+                                  u'sp': urllib.parse.unquote([url_item for url_item in format_item[u'cipher'].split("&") if "sp=" in url_item][0].split("=")[1]),
+                                  u's': urllib.parse.unquote([url_item for url_item in format_item[u'cipher'].split("&") if "s=" in url_item][0].split("=")[1]),
+                                  u'type': format_item[u'mimeType'],
+                                  u'quality': format_item[u'quality'],
+                                  u'itag': format_item[u'itag']} for format_item in formats]
     else:
         stream_data[key] = [
             {k: unquote(v) for k, v in parse_qsl(i)}


### PR DESCRIPTION
Add a try and except to handle cases where the stream_data json does not contain stream_data['player_response'])['streamingData']['formats']